### PR TITLE
PagerDuty Handler To Support Dedup Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ## Usage
 
+PagerDuty supports dedup. Dedup is useful when you want to create a single alert (for a group of checks). Only one alert is sent out even if the checks fail at the same time. The following example groups check_service_`n` together for a single host. `dedup_rules` take in regular expressions as keys and re-write rules as values. `dedup_rules` entry is optional. 
+
 ```
 {
   "pagerduty": {
@@ -23,6 +25,9 @@
     },
     "team_name2": {
       "api_key": "34567"
+    },
+    "dedup_rules": {
+      "(.*)/check_service_(\\d+)": "\\1/check_service"
     }
   }
 }

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -22,7 +22,12 @@ require 'redphone/pagerduty'
 class Pagerduty < Sensu::Handler
   def incident_key # rubocop:disable all
     source = @event['check']['source'] || @event['client']['name']
-    [source, @event['check']['name']].join('/')
+    incident_id = [source, @event['check']['name']].join('/')
+    dedup_rules = settings['pagerduty']['dedup_rules'] || {}
+    dedup_rules.each do |key, val|
+      incident_id = incident_id.gsub(Regexp.new(key), val)
+    end
+    incident_id
   end
 
   def handle # rubocop:disable all


### PR DESCRIPTION
One of the most distinguishing features of PagerDuty is its dedup capability.
This PR is to add dedup capability to the pagerduty handler.

This does not impact existing use of pagerduty handler if no `dedup_rules` are specified in the pagerduty json configuration file.
