### PR TITLE
adding override from client

### DIFF
--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -8,6 +8,10 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 #
+# Note: The sensu api token could also be configured on a per client or per check basis.
+#       By defining the "pager_team" attribute in the client config file or the check config.
+#       The override order will be client > check > json_config
+#
 # Dependencies:
 #
 #   sensu-plugin >= 1.0.0
@@ -40,7 +44,9 @@ class Pagerduty < Sensu::Handler
 
   def handle
     json_config = config[:json_config]
-    if @event['check']['pager_team']
+    if @event['client']['pager_team']
+      api_key = settings[json_config][@event['client']['pager_team']]['api_key']
+    elsif @event['check']['pager_team']
       api_key = settings[json_config][@event['check']['pager_team']]['api_key']
     else
       api_key = settings[json_config]['api_key']


### PR DESCRIPTION
This will allow for greater reusability for checks that alert to pagerduty. Allowing multiple escalation paths to use the same check but specify on the client level which escalation path to take. This is similar to how the hipchat handler does it.
