### PR TITLE
Can override which PagerDuty API Token you use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 ## Files
  * bin/handler-pagerduty.rb
+ * bin/mutator-pagerduty-priority-override.rb
 
 ## Usage
 

--- a/bin/mutator-pagerduty-priority-override.rb
+++ b/bin/mutator-pagerduty-priority-override.rb
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+#
+# PagerDuty
+# ===
+#
+# DESCRIPTION:
+#   This mutator take the Client hash and looks for overrides of the pager_team.
+#   PagerDuty Handler looks for client['pager_team'] to know which pager duty api token to use.
+#   This will allow user to set high and low priority alerts on the client as a whole,
+#   or on a check by check basis.  This will also allow override on a warning and critical basis
+#   for each check.
+#
+#  EX: Override all warnings on host
+#  client.pd_override.baseline.warning: <value to override pager_team with>
+#
+#  EX: Override warning on host for specific check
+#  client.pd_override.<check_name>.warning: <value to override pager_team with>
+#
+# OUTPUT:
+#   Sensu event with pager_team value changed if an override is passed.
+#
+# PLATFORM:
+#   all
+#
+# DEPENDENCIES:
+#   none
+#
+# Copyright 2015 Zach Bintliff <https://github.com/zbintliff>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+require 'json'
+
+module Sensu
+  module Mutator
+    class PagerDuty
+      class PriorityOverride
+        ## Make it a class that takes an IO object for easier testing
+        def execute(input = STDIN)
+          # parse event
+          event = JSON.parse(input.read, symbolize_names: true)
+
+          check_name = event[:check][:name]
+          status = get_status_string(event[:check])
+
+          baseline_override = get_override(event, 'baseline', status)
+          check_override = get_override(event, check_name, status)
+
+          if !check_override.nil?
+            event[:client][:pager_team] = check_override
+          elsif !baseline_override.nil?
+            event[:client][:pager_team] = baseline_override
+          end
+          JSON.dump(event)
+        end
+
+        def get_status_string(check)
+          status = check[:status]
+          if status == 1
+            return 'warning'
+          elsif status == 0
+            ## 0 means its a resolve event, to know which PagerDuty API to resolve on
+            ## we need to look at previous alert
+            ## strangely enough the history array in the event is an array of strings...
+            return get_status_string(status: check[:history][-2].to_i)
+          else
+            return 'critical'
+          end
+        end
+
+        def get_override(event, check, status)
+          return nil if !event[:client].key?(:pd_override) || !event[:client][:pd_override].key?(check.to_sym)
+          event[:client][:pd_override][check.to_sym][status.to_sym]
+        end
+      end
+    end
+  end
+end
+
+## Is called from Gem script. Program name is full path to this script
+### __FILE__ is the initial script ran, which is
+### /usr/local/bin/mutator-pagerduty-priority-override.rb
+if $PROGRAM_NAME.include?(__FILE__.split('/').last)
+  mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+  puts mutator.execute
+end

--- a/test/bin/mutator-pagerduty-priority-override_spec.rb
+++ b/test/bin/mutator-pagerduty-priority-override_spec.rb
@@ -1,0 +1,219 @@
+require 'json'
+require_relative '../spec_helper.rb'
+require_relative '../../bin/mutator-pagerduty-priority-override.rb'
+
+describe 'Mutators' do
+  before do
+    @script = File.expand_path('../../bin/mutator-pagerduty-priority-override.rb', File.dirname(__FILE__))
+  end
+
+  it 'should pass event through -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('no_override_critical.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pager_team])
+  end
+
+  it 'should pass event through -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('no_override_warning.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pager_team])
+  end
+
+  it 'should override with baseline when status matches -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('baseline_override_critical_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][:baseline][:critical])
+  end
+
+  it 'should override with baseline when status matches -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('baseline_override_warning_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][:baseline][:warning])
+  end
+
+  it 'should override with check when status matches -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('check_override_critical_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][event_input[:check][:name].to_sym][:critical])
+  end
+
+  it 'should override with check when status matches -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('check_override_warning_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][event_input[:check][:name].to_sym][:warning])
+  end
+
+  it 'should use check override if baseline is also provided -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('check_and_baseline_override_critical_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][event_input[:check][:name].to_sym][:critical])
+  end
+
+  it 'should use check override if baseline is also provided -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('check_and_baseline_override_warning_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][event_input[:check][:name].to_sym][:warning])
+  end
+
+  it 'should use check on recovery if provided -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('recovery_check_critical_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][event_input[:check][:name].to_sym][:critical])
+  end
+
+  it 'should use check on recovery if provided -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('recovery_check_warning_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][event_input[:check][:name].to_sym][:warning])
+  end
+
+  it 'should use baseline on recovery if provided and check is not -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('recovery_baseline_critical_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][:baseline][:critical])
+  end
+
+  it 'should use baseline on recovery if provided and check is not -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('recovery_baseline_warning_event.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).not_to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pd_override][:baseline][:warning])
+  end
+
+  it 'pass event recovery through when neither baseline nor check is used -- critical' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('recovery_no_override_critical.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pager_team])
+  end
+
+  it 'pass recovery event through when neither baseline nor check is used -- warning' do
+    mutator = Sensu::Mutator::PagerDuty::PriorityOverride.new
+    io_obj = fixture('recovery_no_override_warning.json')
+
+    raw_input = io_obj.read
+    io_obj.rewind
+    raw_output = mutator.execute(io_obj)
+
+    event_input = JSON.parse(raw_input, symbolize_names: true)
+    json_output = JSON.parse(raw_output, symbolize_names: true)
+
+    expect(raw_output.strip).to eql(JSON.dump(event_input))
+    expect(json_output[:client][:pager_team]).to eql(event_input[:client][:pager_team])
+  end
+end

--- a/test/fixtures/baseline_override_critical_event.json
+++ b/test/fixtures/baseline_override_critical_event.json
@@ -1,0 +1,37 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 2,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/baseline_override_warning_event.json
+++ b/test/fixtures/baseline_override_warning_event.json
@@ -1,0 +1,37 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 1,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/check_and_baseline_override_critical_event.json
+++ b/test/fixtures/check_and_baseline_override_critical_event.json
@@ -1,0 +1,41 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      },
+      "frontend_http_check": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 2,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/check_and_baseline_override_warning_event.json
+++ b/test/fixtures/check_and_baseline_override_warning_event.json
@@ -1,0 +1,41 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      },
+      "frontend_http_check": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 1,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/check_override_critical_event.json
+++ b/test/fixtures/check_override_critical_event.json
@@ -1,0 +1,37 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "frontend_http_check": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 2,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/check_override_warning_event.json
+++ b/test/fixtures/check_override_warning_event.json
@@ -1,0 +1,37 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "frontend_http_check": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 1,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/no_override_critical.json
+++ b/test/fixtures/no_override_critical.json
@@ -1,0 +1,31 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 2,
+    "handler": "slack",
+    "history": [
+      "0",
+      "2"
+    ]
+  }
+}

--- a/test/fixtures/no_override_warning.json
+++ b/test/fixtures/no_override_warning.json
@@ -1,0 +1,31 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 1,
+    "handler": "slack",
+    "history": [
+      "0",
+      "1"
+    ]
+  }
+}

--- a/test/fixtures/recovery_baseline_critical_event.json
+++ b/test/fixtures/recovery_baseline_critical_event.json
@@ -1,0 +1,41 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      },
+      "SOME_OTHER_CHECK": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 0,
+    "handler": "slack",
+    "history": [
+      "2",
+      "0"
+    ]
+  }
+}

--- a/test/fixtures/recovery_baseline_warning_event.json
+++ b/test/fixtures/recovery_baseline_warning_event.json
@@ -1,0 +1,41 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      },
+      "SOME_OTHER_CHECK": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 0,
+    "handler": "slack",
+    "history": [
+      "1",
+      "0"
+    ]
+  }
+}

--- a/test/fixtures/recovery_check_critical_event.json
+++ b/test/fixtures/recovery_check_critical_event.json
@@ -1,0 +1,41 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      },
+      "frontend_http_check": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 0,
+    "handler": "slack",
+    "history": [
+      "2",
+      "0"
+    ]
+  }
+}

--- a/test/fixtures/recovery_check_warning_event.json
+++ b/test/fixtures/recovery_check_warning_event.json
@@ -1,0 +1,41 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159,
+    "pd_override": {
+      "baseline": {
+        "warning": "BASELINET_WARNING_OVERRIDE",
+        "critical": "BASELINE_CRITICAL_OVERRIDE"
+      },
+      "frontend_http_check": {
+        "warning": "CHECK_WARNING_OVERRIDE",
+        "critical": "CHECK_CRITICAL_OVERRIDE"
+      }
+    }
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 0,
+    "handler": "slack",
+    "history": [
+      "1",
+      "0"
+    ]
+  }
+}

--- a/test/fixtures/recovery_no_override_critical.json
+++ b/test/fixtures/recovery_no_override_critical.json
@@ -1,0 +1,31 @@
+{
+  "action": "resolve",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 0,
+    "handler": "slack",
+    "history": [
+      "2",
+      "0"
+    ]
+  }
+}

--- a/test/fixtures/recovery_no_override_warning.json
+++ b/test/fixtures/recovery_no_override_warning.json
@@ -1,0 +1,31 @@
+{
+  "action": "resolve",
+  "occurrences": 1,
+  "client": {
+    "name": "i-424242",
+    "address": "8.8.8.8",
+    "subscriptions": [
+      "production",
+      "webserver",
+      "mysql"
+    ],
+    "pager_team": "TEST_TEAM",
+    "timestamp": 1326390159
+  },
+  "check":{
+    "name": "frontend_http_check",
+    "issued": 1326390169,
+    "subscribers":[
+      "frontend"
+    ],
+    "interval": 60,
+    "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
+    "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",
+    "status": 0,
+    "handler": "slack",
+    "history": [
+      "1",
+      "0"
+    ]
+  }
+}

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,15 @@
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
+
+RSpec.configure do |c|
+  c.formatter = :documentation
+  c.color = true
+end
+
+def fixture_path
+  File.expand_path('../fixtures', __FILE__)
+end
+
+def fixture(f)
+  File.new(File.join(fixture_path, f))
+end


### PR DESCRIPTION
In the client hash you can override all of them (so alerts go one way and critical go to another). Or on specific checks.
