### PR TITLE
choose "api_key" based on check status

### DIFF
--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -51,7 +51,7 @@ class PagerdutyHandler < Sensu::Handler
         settings[json_config][@event['client']['pager_team']]['api_key']
       elsif @event['check']['pager_team']
         settings[json_config][@event['check']['pager_team']]['api_key']
-      elsif @event['check']['pager_status'] && !settings[json_config][@event['check']['pager_status']]['api_key'].nil?
+      elsif @event['check']['pager_status'] && !settings[json_config][@event['check']['pager_status']].nil?
         settings[json_config][@event['check']['pager_status']]['api_key']
       else
         settings[json_config]['api_key']

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -51,6 +51,8 @@ class PagerdutyHandler < Sensu::Handler
         settings[json_config][@event['client']['pager_team']]['api_key']
       elsif @event['check']['pager_team']
         settings[json_config][@event['check']['pager_team']]['api_key']
+      elsif @event['check']['pager_status'] && !settings[json_config][@event['check']['pager_status']]['api_key'].nil?
+        settings[json_config][@event['check']['pager_status']]['api_key']
       else
         settings[json_config]['api_key']
       end

--- a/bin/mutator-pagerduty-priority-override.rb
+++ b/bin/mutator-pagerduty-priority-override.rb
@@ -51,6 +51,7 @@ module Sensu
           elsif !baseline_override.nil?
             event[:client][:pager_team] = baseline_override
           end
+          event[:check][:pager_status] = status
           JSON.dump(event)
         end
 


### PR DESCRIPTION
Use a different pagerduty api key depending on the sensu alert severity (warning, critical).
