### PR TITLE
- pass event details to resolv method correctly

### DIFF
--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -71,7 +71,8 @@ class PagerdutyHandler < Sensu::Handler
                               details: @event)
           when 'resolve'
             pagerduty.get_incident([incident_key_prefix, incident_key].compact.join('')).resolve(
-              [description_prefix, event_summary].compact.join(' '), @event)
+              [description_prefix, event_summary].compact.join(' '),
+              details: @event)
           end
           puts 'pagerduty -- ' + @event['action'].capitalize + 'd incident -- ' + incident_key
         rescue Net::HTTPServerException => error


### PR DESCRIPTION
This is in reference to issue: https://github.com/sensu-plugins/sensu-plugins-pagerduty/issues/20

This resolves the issue of a majority of events not being auto-resolved by passing the event payload correctly to the resolve method. It does not fix the scenario whereby pagerduty returns a successful response even if the payload > 1024 characters, however I've opened an issue with Pagerduty to resolve on their end.
