### PR TITLE
Add proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+- Proxy support
+
 ## [1.0.0] - 2016-04-12
 
 NOTE: There is no new functionality in this release but with the addition of test coverage we are

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ And I also have the following client hash:
 
 ```
 
+## Usage of Proxy
+
+```
+{
+  "pagerduty": {
+    "api_key": "12345",
+    "proxy_host": "my.proxy.fqdn",
+    "proxy_port": "8080",
+    "proxy_username": "",
+    "proxy_password": ""
+  }
+}
+```
+
+
 If an `critical` event is triggered from "my.host.fqdn" that is not named `check_disk` it will alert the default (with value api_key: 12345).  If a `warning` event is triggered that is not `check_disk` it will alert the `low_proirity` escalation service.  If any `check_disk` alert is triggerd it will the alert the `ops` escalation. 
 
 ## Installation

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -56,12 +56,33 @@ class PagerdutyHandler < Sensu::Handler
       end
   end
 
+  def get_proxy_settings
+      proxy_settings = Hash.new
+
+      proxy_settings['proxy_host']     = settings[json_config]['proxy_host']     || nil
+      proxy_settings['proxy_port']     = settings[json_config]['proxy_port']     || 3128
+      proxy_settings['proxy_username'] = settings[json_config]['proxy_username'] || ""
+      proxy_settings['proxy_password'] = settings[json_config]['proxy_password'] || ""
+
+      proxy_settings
+  end
+
   def handle(pd_client = nil)
     incident_key_prefix = settings[json_config]['incident_key_prefix']
     description_prefix = settings[json_config]['description_prefix']
+    proxy_settings = get_proxy_settings
     begin
       timeout(5) do
-        pagerduty = pd_client || Pagerduty.new(api_key)
+        if proxy_settings['proxy_host']
+          pagerduty = pd_client || Pagerduty.new(api_key,
+                                                 proxy_host: proxy_settings['proxy_host'],
+                                                 proxy_port: proxy_settings['proxy_port'],
+                                                 proxy_username: proxy_settings['proxy_username'],
+                                                 proxy_password: proxy_settings['proxy_password'],
+                                                )
+        else
+          pagerduty = pd_client || Pagerduty.new(api_key)
+        end
 
         begin
           case @event['action']

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -56,21 +56,21 @@ class PagerdutyHandler < Sensu::Handler
       end
   end
 
-  def get_proxy_settings
-      proxy_settings = Hash.new
+  def proxy_settings
+    proxy_settings = {}
 
-      proxy_settings['proxy_host']     = settings[json_config]['proxy_host']     || nil
-      proxy_settings['proxy_port']     = settings[json_config]['proxy_port']     || 3128
-      proxy_settings['proxy_username'] = settings[json_config]['proxy_username'] || ""
-      proxy_settings['proxy_password'] = settings[json_config]['proxy_password'] || ""
+    proxy_settings['proxy_host']     = settings[json_config]['proxy_host']     || nil
+    proxy_settings['proxy_port']     = settings[json_config]['proxy_port']     || 3128
+    proxy_settings['proxy_username'] = settings[json_config]['proxy_username'] || ''
+    proxy_settings['proxy_password'] = settings[json_config]['proxy_password'] || ''
 
-      proxy_settings
+    proxy_settings
   end
 
   def handle(pd_client = nil)
     incident_key_prefix = settings[json_config]['incident_key_prefix']
     description_prefix = settings[json_config]['description_prefix']
-    proxy_settings = get_proxy_settings
+    proxy_settings = proxy_settings()
     begin
       timeout(5) do
         if proxy_settings['proxy_host']
@@ -78,8 +78,7 @@ class PagerdutyHandler < Sensu::Handler
                                                  proxy_host: proxy_settings['proxy_host'],
                                                  proxy_port: proxy_settings['proxy_port'],
                                                  proxy_username: proxy_settings['proxy_username'],
-                                                 proxy_password: proxy_settings['proxy_password'],
-                                                )
+                                                 proxy_password: proxy_settings['proxy_password'])
         else
           pagerduty = pd_client || Pagerduty.new(api_key)
         end

--- a/sensu-plugins-pagerduty.gemspec
+++ b/sensu-plugins-pagerduty.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsPagerduty::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'pagerduty',    '2.0.1'
+  s.add_runtime_dependency 'pagerduty',    '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/test/bin/handler-pagerduty_spec.rb
+++ b/test/bin/handler-pagerduty_spec.rb
@@ -40,7 +40,7 @@ describe 'Handlers' do
       expect(incident_key).to eq('i-424242/frontend_http_check')
     end
 
-    it 'should return incident key with warning on resolve' do
+    it 'should return incident key with critical on resolve' do
       io_obj = fixture('recovery_no_override_critical.json')
       @handler.read_event(io_obj)
       incident_key = @handler.incident_key


### PR DESCRIPTION
This PR will give proxy support to the PagerDuty handler.
1. I had to update the PagerDuty gem to v2.1.0 to be able to go though a proxy ( no support before this version ).
2. I also fixed a quick typo in one of the tests.

Setting the following in the handler config will enable the proxy mode:

```
"pagerduty": {
    "api_key": "api_key",
    "proxy_host": "proxy_host",
    "proxy_port": "proxy_port",
    "proxy_username": "",
    "proxy_password": ""
}
```
