### PR TITLE
Add support for PagerDuty event contexts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Contexts support (@zroger)
 
 ## [2.0.0] - 2016-06-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In the Client hash you can define a `pager_team` key value pair.  If the the cli
 
 Please note, this sets the escalation path on the whole host. If you want more granular control on escalation paths please view the Mutator section below.
 
+In the Check hash you can define a `pagerduty_contexts` list to send contextual links and images with your events. This list should conform to the [PagerDuty documentation](https://developer.pagerduty.com/documentation/integration/events/trigger#contexts) about contexts.
+
 ## Usage of Priority Overide Mutator
 
 This mutator allows you to have fine grain control on PagerDuty escalation paths based on data within the client hash.  The mutator will look in the following locations where `#{event_level}` is `warning` and `critical` (unknown, is replaced by critical), and `#{check_name}` is the name of the check. Items located lower in the list take precedence:

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -67,6 +67,10 @@ class PagerdutyHandler < Sensu::Handler
     proxy_settings
   end
 
+  def contexts
+    @contexts ||= @event['check']['pagerduty_contexts'] || {}
+  end
+
   def handle(pd_client = nil)
     incident_key_prefix = settings[json_config]['incident_key_prefix']
     description_prefix = settings[json_config]['description_prefix']
@@ -88,7 +92,8 @@ class PagerdutyHandler < Sensu::Handler
           when 'create'
             pagerduty.trigger([description_prefix, event_summary].compact.join(' '),
                               incident_key: [incident_key_prefix, incident_key].compact.join(''),
-                              details: @event)
+                              details: @event,
+                              contexts: contexts)
           when 'resolve'
             pagerduty.get_incident([incident_key_prefix, incident_key].compact.join('')).resolve(
               [description_prefix, event_summary].compact.join(' '), @event

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -68,7 +68,7 @@ class PagerdutyHandler < Sensu::Handler
   end
 
   def contexts
-    @contexts ||= @event['check']['pagerduty_contexts'] || {}
+    @contexts ||= @event['check']['pagerduty_contexts'] || []
   end
 
   def handle(pd_client = nil)

--- a/test/bin/handler-pagerduty_spec.rb
+++ b/test/bin/handler-pagerduty_spec.rb
@@ -79,6 +79,21 @@ describe 'Handlers' do
     end
   end
 
+  describe '#contexts' do
+    it 'should return contexts hash from check' do
+      io_obj = fixture('check_with_contexts.json')
+      @handler.read_event(io_obj)
+      expect(@handler.contexts).to eq(
+        [
+          {
+            'type' => 'link',
+            'href' => 'http://example.com/'
+          }
+        ]
+      )
+    end
+  end
+
   describe '#handle' do
     it 'should create ticket' do
       stub_pd_client = double
@@ -87,6 +102,14 @@ describe 'Handlers' do
       allow(@handler).to receive(:json_config).and_return('pagerduty')
       allow(@handler).to receive(:incident_key).and_return('stub_incident_key')
       allow(@handler).to receive(:event_summary).and_return('test_summary')
+      allow(@handler).to receive(:contexts).and_return(
+        [
+          {
+            'type' => 'link',
+            'href' => 'http://example.com/'
+          }
+        ]
+      )
       expect(stub_pd_client).to receive(:trigger).with(
         'test_summary',
         incident_key: 'stub_incident_key',
@@ -95,7 +118,13 @@ describe 'Handlers' do
           'occurrences' => 1,
           'check' => {},
           'client' => {}
-        }
+        },
+        contexts: [
+          {
+            'type' => 'link',
+            'href' => 'http://example.com/'
+          }
+        ]
       )
       @handler.handle(stub_pd_client)
     end

--- a/test/bin/handler-pagerduty_spec.rb
+++ b/test/bin/handler-pagerduty_spec.rb
@@ -80,6 +80,12 @@ describe 'Handlers' do
   end
 
   describe '#contexts' do
+    it 'should return list as default' do
+      io_obj = fixture('minimal_create.json')
+      @handler.read_event(io_obj)
+      expect(@handler.contexts).to eq([])
+    end
+
     it 'should return contexts hash from check' do
       io_obj = fixture('check_with_contexts.json')
       @handler.read_event(io_obj)

--- a/test/fixtures/check_with_contexts.json
+++ b/test/fixtures/check_with_contexts.json
@@ -1,0 +1,13 @@
+{
+  "action": "create",
+  "occurrences": 1,
+  "client": {},
+  "check": {
+    "pagerduty_contexts": [
+      {
+        "type": "link",
+        "href": "http://example.com/"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
PagerDuty event contexts can be used to add more links and iamges to an
event for better contextual information. This allows a check definition
to specify contexts to be passed to the PagerDuty event trigger API.

See https://developer.pagerduty.com/documentation/integration/events/trigger#contexts 
for the documentation about contexts.
