### PR TITLE
Resolve timeout deprecation warning and increase timeout to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Contexts support (@zroger)
+- Update timeout syntax and extend to 10 seconds. (@luckymike)
 
 ## [2.0.0] - 2016-06-29
 ### Added
@@ -39,8 +40,8 @@ marking it as a stable 1.0.0 release.
 
 ## [0.0.8] - 2015-12-10
 ### Added
-- Added a handler to allow overrides based on priority, now you can different 
-  alerts trigger different PagerDuty API endpoints. For example one can hit a high 
+- Added a handler to allow overrides based on priority, now you can different
+  alerts trigger different PagerDuty API endpoints. For example one can hit a high
   priority endpoint but warning can hit a lowpriority point.
 
 ### Changed

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -76,7 +76,7 @@ class PagerdutyHandler < Sensu::Handler
     description_prefix = settings[json_config]['description_prefix']
     proxy_settings = proxy_settings()
     begin
-      timeout(5) do
+      Timeout.timeout(10) do
         if proxy_settings['proxy_host']
           pagerduty = pd_client || Pagerduty.new(api_key,
                                                  proxy_host: proxy_settings['proxy_host'],


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
This resolves `timeout` deprecation warnings and increases the timeout from 5 to 10 seconds. I observed that a 5 second timeout failed 100% of the time on a fairly average system, while 10 seconds worked 100% of the time. 

#### Known Compatablity Issues