### PR TITLE
Dynamic description prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ And I also have the following client hash:
 }
 ```
 
+If a `critical` event is triggered from "my.host.fqdn" that is not named `check_disk` it will alert the default (with value api_key: 12345).  If a `warning` event is triggered that is not `check_disk` it will alert the `low_proirity` escalation service.  If any `check_disk` alert is triggerd it will the alert the `ops` escalation.
+
+
 ## Adding Dynamic Event Description Prefix 
 
 You can add a custom field from the Sensu client config as a description prefix, like the host name, to add more context to the event description:
@@ -132,8 +135,6 @@ You can add a custom field from the Sensu client config as a description prefix,
   }
 }
 ```
-
-If a `critical` event is triggered from "my.host.fqdn" that is not named `check_disk` it will alert the default (with value api_key: 12345).  If a `warning` event is triggered that is not `check_disk` it will alert the `low_proirity` escalation service.  If any `check_disk` alert is triggerd it will the alert the `ops` escalation.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ And I also have the following client hash:
 }
 ```
 
+## Adding Dynamic Event Description Prefix 
+
+You can add a custom field from the Sensu client config as a description prefix, like the host name, to add more context to the event description:
+
+```
+{
+  "pagerduty": {
+    "api_key": "12345",
+    "dynamic_description_prefix_key" : "name",
+  }
+}
+```
 
 If a `critical` event is triggered from "my.host.fqdn" that is not named `check_disk` it will alert the default (with value api_key: 12345).  If a `warning` event is triggered that is not `check_disk` it will alert the `low_proirity` escalation service.  If any `check_disk` alert is triggerd it will the alert the `ops` escalation.
 

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -70,10 +70,20 @@ class PagerdutyHandler < Sensu::Handler
   def contexts
     @contexts ||= @event['check']['pagerduty_contexts'] || []
   end
+  
+  def description_prefix
+    
+    if @event['client'].key?(settings[json_config]['dynamic_description_prefix_key'])
+      @description_prefix = "(#{@event['client'][settings[json_config]['dynamic_description_prefix_key']]})"
+    else
+      @description_prefix = settings[json_config]['description_prefix']
+    end
+
+  end
 
   def handle(pd_client = nil)
     incident_key_prefix = settings[json_config]['incident_key_prefix']
-    description_prefix = settings[json_config]['description_prefix']
+    description_prefix = description_prefix()
     proxy_settings = proxy_settings()
     begin
       Timeout.timeout(10) do

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -70,15 +70,13 @@ class PagerdutyHandler < Sensu::Handler
   def contexts
     @contexts ||= @event['check']['pagerduty_contexts'] || []
   end
-  
-  def description_prefix
-    
-    if @event['client'].key?(settings[json_config]['dynamic_description_prefix_key'])
-      @description_prefix = "(#{@event['client'][settings[json_config]['dynamic_description_prefix_key']]})"
-    else
-      @description_prefix = settings[json_config]['description_prefix']
-    end
 
+  def description_prefix
+    @description_prefix = if @event['client'].key?(settings[json_config]['dynamic_description_prefix_key'])
+                            "(#{@event['client'][settings[json_config]['dynamic_description_prefix_key']]})"
+                          else
+                            settings[json_config]['description_prefix']
+                          end
   end
 
   def handle(pd_client = nil)

--- a/test/bin/handler-pagerduty_spec.rb
+++ b/test/bin/handler-pagerduty_spec.rb
@@ -101,7 +101,6 @@ describe 'Handlers' do
   end
 
   describe '#handle' do
-    
     it 'should create ticket with dynamic perfix' do
       stub_pd_client = double
       io_obj = fixture('create_dynamic_prefix.json')
@@ -123,7 +122,7 @@ describe 'Handlers' do
         incident_key: 'stub_incident_key',
         details: {
           'action' => 'create',
-          'client'=>{'name'=>'i-424242'},
+          'client' => { 'name' => 'i-424242' },
           'occurrences' => 1,
           'check' => {}
         },
@@ -136,7 +135,6 @@ describe 'Handlers' do
       )
       @handler.handle(stub_pd_client)
     end
-    
 
     it 'should create ticket' do
       stub_pd_client = double

--- a/test/bin/handler-pagerduty_spec.rb
+++ b/test/bin/handler-pagerduty_spec.rb
@@ -101,6 +101,43 @@ describe 'Handlers' do
   end
 
   describe '#handle' do
+    
+    it 'should create ticket with dynamic perfix' do
+      stub_pd_client = double
+      io_obj = fixture('create_dynamic_prefix.json')
+      @handler.read_event(io_obj)
+      allow(@handler).to receive(:event_summary).and_return('(i-424242) test_summary')
+      allow(@handler).to receive(:json_config).and_return('pagerduty')
+      allow(@handler).to receive(:incident_key).and_return('stub_incident_key')
+      allow(@handler).to receive(:event_summary).and_return('test_summary')
+      allow(@handler).to receive(:contexts).and_return(
+        [
+          {
+            'type' => 'link',
+            'href' => 'http://example.com/'
+          }
+        ]
+      )
+      expect(stub_pd_client).to receive(:trigger).with(
+        '(i-424242) test_summary',
+        incident_key: 'stub_incident_key',
+        details: {
+          'action' => 'create',
+          'client'=>{'name'=>'i-424242'},
+          'occurrences' => 1,
+          'check' => {}
+        },
+        contexts: [
+          {
+            'type' => 'link',
+            'href' => 'http://example.com/'
+          }
+        ]
+      )
+      @handler.handle(stub_pd_client)
+    end
+    
+
     it 'should create ticket' do
       stub_pd_client = double
       io_obj = fixture('minimal_create.json')

--- a/test/fixtures/create_dynamic_prefix.json
+++ b/test/fixtures/create_dynamic_prefix.json
@@ -1,0 +1,6 @@
+{
+  "action": "create",
+  "client": {
+    "name": "i-424242"
+  }
+}

--- a/test/fixtures/pagerduty_settings.json
+++ b/test/fixtures/pagerduty_settings.json
@@ -1,5 +1,6 @@
 {
   "pagerduty": {
+    "dynamic_description_prefix_key" : "name",
     "api_key": "BASE_KEY",
     "CHECK_OVERRIDE": {
       "api_key": "CHECK_OVERRIDE"


### PR DESCRIPTION
New feature that allows adding some prefix to the description field, this will primarily  be used to add the hostname of the source of the check but could be any field from the client configuration hash.

