### PR TITLE
Pagerduty Handler can not handle flapping events: fixes #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- support for flapping events to be created
 
 ## [2.2.0] - 2017-03-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Usage of Handler
 
-PagerDuty supports dedup. Dedup is useful when you want to create a single alert (for a group of checks). Only one alert is sent out even if the checks fail at the same time. The following example groups check_service_`n` together for a single host. `dedup_rules` take in regular expressions as keys and re-write rules as values. `dedup_rules` entry is optional. 
+PagerDuty supports dedup. Dedup is useful when you want to create a single alert (for a group of checks). Only one alert is sent out even if the checks fail at the same time. The following example groups check_service_`n` together for a single host. `dedup_rules` take in regular expressions as keys and re-write rules as values. `dedup_rules` entry is optional.
 
 ```
 {
@@ -33,7 +33,7 @@ PagerDuty supports dedup. Dedup is useful when you want to create a single alert
 }
 ```
 
-In the Client hash you can define a `pager_team` key value pair.  If the the client hash contains the `pager_team` key it will then no longer use the default `pagerduty.api_key` from the above hash but will look for the value given in the client. The following client hash will  alert using the team_name1 api key instead of the default api_key. This will allow different teams/hosts to alert different escalation paths. 
+In the Client hash you can define a `pager_team` key value pair.  If the the client hash contains the `pager_team` key it will then no longer use the default `pagerduty.api_key` from the above hash but will look for the value given in the client. The following client hash will  alert using the team_name1 api key instead of the default api_key. This will allow different teams/hosts to alert different escalation paths.
 
 ```
 {
@@ -123,7 +123,7 @@ And I also have the following client hash:
 If a `critical` event is triggered from "my.host.fqdn" that is not named `check_disk` it will alert the default (with value api_key: 12345).  If a `warning` event is triggered that is not `check_disk` it will alert the `low_proirity` escalation service.  If any `check_disk` alert is triggerd it will the alert the `ops` escalation.
 
 
-## Adding Dynamic Event Description Prefix 
+## Adding Dynamic Event Description Prefix
 
 You can add a custom field from the Sensu client config as a description prefix, like the host name, to add more context to the event description:
 
@@ -132,6 +132,17 @@ You can add a custom field from the Sensu client config as a description prefix,
   "pagerduty": {
     "api_key": "12345",
     "dynamic_description_prefix_key" : "name",
+  }
+}
+```
+
+## Flapping Incidents
+By default handlers do not handle flapping incidents: [handler configuration documentation](https://sensuapp.org/docs/0.24/reference/handlers.html#handler-configuration) in order to change this you must set handle_flapping in your handler config like this:
+```json
+{
+  "pagerduty": {
+    "api_key": "12345",
+    "handle_flapping": true
   }
 }
 ```

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -98,7 +98,7 @@ class PagerdutyHandler < Sensu::Handler
 
         begin
           case @event['action']
-          when 'create'
+          when 'create', 'flapping'
             pagerduty.trigger([description_prefix, event_summary].compact.join(' '),
                               incident_key: [incident_key_prefix, incident_key].compact.join(''),
                               details: @event,


### PR DESCRIPTION
Added support and required doc to allow pagerduty to recieve flapping events

## Pull Request Checklist

#33 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
Allow handling of flappign events being sent to pagerduty


