### PR TITLE
issue_42: ordering from most specific to least specific for team sett…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Change
+- changed the precedence of pager_team evaluation from `client -> check -> json_config`  to `check -> client -> json_config` (@guru-beach)
 ### Added
 - support for flapping events to be created
 

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -10,7 +10,7 @@
 #
 # Note: The sensu api token could also be configured on a per client or per check basis.
 #       By defining the "pager_team" attribute in the client config file or the check config.
-#       The override order will be client > check > json_config
+#       The override order will be check > client > json_config
 #
 # Dependencies:
 #

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -47,10 +47,10 @@ class PagerdutyHandler < Sensu::Handler
 
   def api_key
     @api_key ||=
-      if @event['client']['pager_team']
-        settings[json_config][@event['client']['pager_team']]['api_key']
-      elsif @event['check']['pager_team']
+      if @event['check']['pager_team']
         settings[json_config][@event['check']['pager_team']]['api_key']
+      elsif @event['client']['pager_team']
+        settings[json_config][@event['client']['pager_team']]['api_key']
       else
         settings[json_config]['api_key']
       end

--- a/test/fixtures/pd_check_override.json
+++ b/test/fixtures/pd_check_override.json
@@ -9,6 +9,7 @@
       "webserver",
       "mysql"
     ],
+    "pager_team": "CLIENT_OVERRIDE",
     "timestamp": 1326390159,
     "pd_override": {
       "frontend_http_check": {

--- a/test/fixtures/pd_client_override.json
+++ b/test/fixtures/pd_client_override.json
@@ -9,7 +9,7 @@
       "webserver",
       "mysql"
     ],
-    "pager_team": "TEST_TEAM",
+    "pager_team": "CLIENT_OVERRIDE",
     "timestamp": 1326390159,
     "pd_override": {
       "frontend_http_check": {
@@ -24,7 +24,6 @@
     "subscribers":[
       "frontend"
     ],
-    "pager_team": "CHECK_OVERRIDE",
     "interval": 60,
     "command": "check_http -I 127.0.0.1 -u http://web.example.com/healthcheck.html -R \'pageok\'",
     "output": "HTTP CRITICAL: HTTP/1.1 503 Service Temporarily Unavailable",

--- a/test/fixtures/pd_client_override.json
+++ b/test/fixtures/pd_client_override.json
@@ -9,7 +9,7 @@
       "webserver",
       "mysql"
     ],
-    "pager_team": "CLIENT_OVERRIDE",
+    "pager_team": "TEST_TEAM",
     "timestamp": 1326390159,
     "pd_override": {
       "frontend_http_check": {


### PR DESCRIPTION
It seems to make more sense to have notifications go from most to least specific settings.   We have many cases where application level checks have different pager_teams and the teams creating those checks don't have access to the node level configurations for pd_override settings.   If no check team is configured, the node level config should be used, and if no node level config, the default api_key should be used.   


## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

