### PR TITLE
add additional error checking when people misuse `json_config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - ruby 2.4 testing (@majormoses)
+- error handling when `json_config` key is not found to help users deal with the problem. Not great but better than a `NilClass` error (@majormoses)
+
+### Changed
+- changed the description of `json_config` to reflect that this is a key not the json file (@majormoses)
 
 ### Fixed
 - PR template typo

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -25,9 +25,9 @@ require 'pagerduty'
 #
 class PagerdutyHandler < Sensu::Handler
   option :json_config,
-         description: 'Config Name',
-         short: '-j JsonConfig',
-         long: '--json_config JsonConfig',
+         description: 'Config key Name, this is not a path to a file but rather the key name within sensu to check',
+         short: '-j JsonConfigKey',
+         long: '--json_config JsonConfigKey',
          required: false,
          default: 'pagerduty'
 
@@ -80,6 +80,10 @@ class PagerdutyHandler < Sensu::Handler
   end
 
   def handle(pd_client = nil)
+    if settings[json_config].nil?
+      p "invalid config: #{options[:json_config]} you need to pass a key and not a file"
+      exit 3 # unknown
+    end
     incident_key_prefix = settings[json_config]['incident_key_prefix']
     description_prefix = description_prefix()
     proxy_settings = proxy_settings()


### PR DESCRIPTION
Basically I have seen many users assume this is a filename when in fact it is a key in the sensu settings hash which by default combines all the `*.json` files in `/etc/sensu/conf.d/` and it's subdirs.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

Maybe not sure but I for sure have seen this lots of time in slack.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
Help users when they misconfigure the handler.

#### Known Compatibility Issues
None