### PR TITLE
If "pager_team" is set in client config, but not in handler config, use default "api_key" in handler config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - PR template typo
-
-## [3.0.0] - 2018-02-09
-### Added
-- if pager_team is not found in the handler json config, the default key will be used instead
+- if pager_team is not found in the handler json config, the default key will be used instead (@internaught)
 
 ## [3.0.0] - 2017-06-01
 ### Breaking Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - PR template typo
 
+## [3.0.0] - 2018-02-09
+### Added
+- if pager_team is not found in the handler json config, the default key will be used instead
+
 ## [3.0.0] - 2017-06-01
 ### Breaking Change
 - changed the precedence of pager_team evaluation from `client -> check -> json_config`  to `check -> client -> json_config` (@guru-beach)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PagerDuty supports dedup. Dedup is useful when you want to create a single alert
 }
 ```
 
-In the Client hash you can define a `pager_team` key value pair.  If the the client hash contains the `pager_team` key it will then no longer use the default `pagerduty.api_key` from the above hash but will look for the value given in the client. The following client hash will  alert using the team_name1 api key instead of the default api_key. This will allow different teams/hosts to alert different escalation paths.
+In the Client hash you can define a `pager_team` key value pair.  If the the client hash contains the `pager_team` key it will then no longer use the default `pagerduty.api_key` from the above hash but will look for the value given in the client. If the value given in the client is not found in the handler specified, then the default `pagerduty.api_key` will be used. The following client hash will alert using the team_name1 api key instead of the default api_key. This will allow different teams/hosts to alert different escalation paths.
 
 ```
 {

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -49,7 +49,7 @@ class PagerdutyHandler < Sensu::Handler
     @api_key ||=
       if @event['check']['pager_team']
         settings[json_config][@event['check']['pager_team']]['api_key']
-      elsif settings[json_config][@event['client']['pager_team']].nil?
+      elsif @event['client']['pager_team'] && settings[json_config][@event['client']['pager_team']].nil?
         puts "you configured your client to use a pager team of #{@event['client']['pager_team']} but it was nil, falling back to default key"
         settings[json_config]['api_key']
       elsif @event['client']['pager_team']

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -49,12 +49,11 @@ class PagerdutyHandler < Sensu::Handler
     @api_key ||=
       if @event['check']['pager_team']
         settings[json_config][@event['check']['pager_team']]['api_key']
+      elsif settings[json_config][@event['client']['pager_team']].nil?
+        puts "you configured your client to use a pager team of #{@event['client']['pager_team']} but it was nil, falling back to default key"
+        settings[json_config]['api_key']
       elsif @event['client']['pager_team']
-        if settings[json_config][@event['client']['pager_team']].nil?
-          settings[json_config]['api_key']
-        else
-          settings[json_config][@event['client']['pager_team']]['api_key']
-        end
+        settings[json_config][@event['client']['pager_team']]['api_key']
       else
         settings[json_config]['api_key']
       end

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -50,7 +50,11 @@ class PagerdutyHandler < Sensu::Handler
       if @event['check']['pager_team']
         settings[json_config][@event['check']['pager_team']]['api_key']
       elsif @event['client']['pager_team']
-        settings[json_config][@event['client']['pager_team']]['api_key']
+        if settings[json_config][@event['client']['pager_team']].nil?
+          settings[json_config]['api_key']
+        else
+          settings[json_config][@event['client']['pager_team']]['api_key']
+        end
       else
         settings[json_config]['api_key']
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
When giving clients the "pager_team" key, we want to pipe alerts to their respective "pager_team" values. However, should that value be absent from the handler json config, we want to use the default API key listed in that handler file, instead of no alert or incident being created at all.

#### Known Compatibility Issues
