### PR TITLE
Using sensu-plugin version 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
-### Changed
-- Using sensu-plugin version 2.0.0
+### Breaking Changes
+- Bumped dependency of `sensu-plugin` to 2.x which will globally disable deprecated event filtering. You can read about it [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@rajiv-g)
 
 ## [3.1.0] - 2018-03-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- Using sensu-plugin version 2.0.0
 
 ## [3.1.0] - 2018-03-17
 ### Added

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -14,7 +14,7 @@
 #
 # Dependencies:
 #
-#   sensu-plugin >= 1.0.0
+#   sensu-plugin >= 2.0.0
 #
 
 require 'sensu-handler'

--- a/bin/handler-pagerduty.rb
+++ b/bin/handler-pagerduty.rb
@@ -14,7 +14,7 @@
 #
 # Dependencies:
 #
-#   sensu-plugin >= 2.0.0
+#   sensu-plugin ~> 2.5
 #
 
 require 'sensu-handler'

--- a/sensu-plugins-pagerduty.gemspec
+++ b/sensu-plugins-pagerduty.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPagerduty::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.0.0'
   s.add_runtime_dependency 'pagerduty',    '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'

--- a/sensu-plugins-pagerduty.gemspec
+++ b/sensu-plugins-pagerduty.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsPagerduty::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 2.0.0'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.5'
   s.add_runtime_dependency 'pagerduty',    '2.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
It will fix #48 

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Sensu events are filtered when using sensu-plugin version 1.2
Event filtering is deprecated in sensu-plugin. So when I upgrade to 2.0.0, pagerduty incident are created.

#### Known Compatibility Issues
